### PR TITLE
org-rainbow-tags.el: select or exclude tags, and colorize agenda views

### DIFF
--- a/README.org
+++ b/README.org
@@ -121,6 +121,30 @@ Full ~use-package~ example:
   (org-mode . org-rainbow-tags-mode))
 #+END_SRC
 
+* Customization
+
+You can selectively choose tags to colorize, using both the
+~org-rainbow-tags-wanted-list~ and ~org-rainbow-tags-wanted-regex~
+options to either select a specific list of tags, or tags matching the
+regular expression, respectively.
+
+This selection can be inverted too by setting the
+~org-rainbow-tags-wanted-invert~ option to non-nil.
+
+The following example colorizes all tags except those matching
+"ATTACH" and "ARCHIVE", as well as any tags that end in a number:
+#+begin_src emacs-lisp
+  (use-package org-rainbow-tags
+    :ensure t
+    :custom
+    (org-rainbow-tags-wanted-list '("ATTACH" "ARCHIVE"))
+    (org-rainbow-tags-wanted-regex (rx (any num) eow))
+    (org-rainbow-tags-wanted-invert t)
+    :hook
+    (org-mode . org-rainbow-tags-mode))
+#+end_src
+
+
 * Known Issues
 ~org-rainbow-tags-mode~ colorizes org tags when it's activated and also when a new
 tag is added/updated with ~org-set-tags-command~ or with ~C-c C-c~ on the headline.

--- a/README.org
+++ b/README.org
@@ -118,7 +118,7 @@ Full ~use-package~ example:
    ;; Default is '(:weight 'bold)
    '(:inverse-video t :box t :weight 'bold))
   :hook
-  (org-mode . org-rainbow-tags-mode))
+  ((org-mode org-agenda-finalize) . org-rainbow-tags-mode))
 #+END_SRC
 
 * Customization
@@ -141,7 +141,7 @@ The following example colorizes all tags except those matching
     (org-rainbow-tags-wanted-regex (rx (any num) eow))
     (org-rainbow-tags-wanted-invert t)
     :hook
-    (org-mode . org-rainbow-tags-mode))
+    ((org-mode org-agenda-finalize) . org-rainbow-tags-mode))
 #+end_src
 
 

--- a/org-rainbow-tags.el
+++ b/org-rainbow-tags.el
@@ -215,7 +215,8 @@ highlighted, barring the ones defined in the mentioned settings."
 
 (defvar org-rainbow-tags--tag-sections-regexp
   (rx (or (regexp org-tag-line-re)
-          (regexp org-rainbow-tags--org-clocktable-regexp)))
+          (regexp org-rainbow-tags--org-clocktable-regexp)
+          (seq (* any) (regexp org-tag-group-re) (* any))))
   "Regular expression matching all tag sections.")
 
 (defvar org-rainbow-tags--overlays '()


### PR DESCRIPTION
This PR adds two independent patches (you can pick and choose):

1. select or exclude tags ([patch](https://github.com/KaratasFurkan/org-rainbow-tags/pull/9/commits/6c2a12b8b08185ad262b9e91e8afa76f9ec18a2b))

    This adds 2 new custom settings: `org-rainbow-tags-wanted-list`, `org-rainbow-tags-wanted-regex` which define an explicit list or a regex to use to filter for tags to highlight, and excludes all other tags from being highlighted.

    One extra setting `org-rainbow-tags-wanted-invert` is used to invert  the above, so that any tags that match the above settings are  excluded and all other tags are highlighted.

     The function  `org-rainbow-tags--valid-tags-p` is added to validate the above custom parameters

2. colorize agenda ([patch](https://github.com/KaratasFurkan/org-rainbow-tags/pull/9/commits/6ec284086db98ed7bfe87f599f7f6c91bef12c19))
 
    Agenda views are now colorized with examples in the readme, as a fix for https://github.com/KaratasFurkan/org-rainbow-tags/issues/7